### PR TITLE
Add public read permissions to all new files in s3, to prevent disrup…

### DIFF
--- a/dis-ingest/src/main/java/io/pivotal/dis/ingest/service/store/FileStoreImpl.java
+++ b/dis-ingest/src/main/java/io/pivotal/dis/ingest/service/store/FileStoreImpl.java
@@ -1,21 +1,29 @@
 package io.pivotal.dis.ingest.service.store;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.GroupGrantee;
+import com.amazonaws.services.s3.model.Permission;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.io.IOUtils;
 
 public class FileStoreImpl implements FileStore {
 
     private final AmazonS3 amazonS3;
     private final String bucketName;
+    private final AccessControlList disruptionsAcl;
 
     public FileStoreImpl(AmazonS3 amazonS3, String bucketName) {
         this.amazonS3 = amazonS3;
         this.bucketName = bucketName;
+        disruptionsAcl = new AccessControlList();
+        disruptionsAcl.grantPermission(GroupGrantee.AllUsers, Permission.Read);
     }
 
     @Override
     public void save(String name, String input) {
-        amazonS3.putObject(bucketName, name, IOUtils.toInputStream(input), null);
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, name, IOUtils.toInputStream(input), null).withAccessControlList(disruptionsAcl);
+        amazonS3.putObject(putObjectRequest);
     }
 
 }

--- a/dis-ingest/src/test/java/io/pivotal/dis/ingest/service/store/FileStoreImplTest.java
+++ b/dis-ingest/src/test/java/io/pivotal/dis/ingest/service/store/FileStoreImplTest.java
@@ -1,6 +1,8 @@
 package io.pivotal.dis.ingest.service.store;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -20,11 +22,13 @@ public class FileStoreImplTest {
 
     @Test
     public void savesTimestampedFileToS3() {
-        Map<String, Object> params = new HashMap<>(); // blech
+        Map<String, Object> params = new HashMap<>();
         AmazonS3 mockAmazonS3 = proxy(AmazonS3.class, "putObject", args -> {
-            params.put("bucketName", args[0]);
-            params.put("key", args[1]);
-            params.put("input", toString((InputStream) args[2]));
+            PutObjectRequest putObjectRequest = (PutObjectRequest) args[0];
+            params.put("bucketName", putObjectRequest.getBucketName());
+            params.put("key", putObjectRequest.getKey());
+            params.put("input", toString((InputStream) putObjectRequest.getInputStream()));
+            params.put("aclGrant", putObjectRequest.getAccessControlList().getGrants().toArray());
         });
 
         FileStoreImpl fileStore = new FileStoreImpl(mockAmazonS3, "bucketName");


### PR DESCRIPTION
, to prevent disruptions.json from being unavailable publicly, which means the android app can't get any data.
